### PR TITLE
Update for compatibility with Shelf 0.6.0+, redstone 0.6.0-beta.1+3

### DIFF
--- a/bin/server.dart
+++ b/bin/server.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:appengine/appengine.dart';
 import 'package:args/args.dart';
 import 'package:http/http.dart' as http;
-import 'package:redstone/server.dart' as app;
+import 'package:redstone/redstone.dart' as app;
 import 'package:react/react.dart';
 import 'package:react/react_server.dart' as react_server;
 import 'package:isomorphic_dart/isomorphic_dart.dart';
@@ -11,20 +11,20 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:shelf_appengine/shelf_appengine.dart' as shelf_ae;
 import 'package:isomorphic_dart/src/apis.dart';
 
-void main(List<String> args) {
+main(List<String> args) async {
   var parser = new ArgParser();
   parser
       ..addOption('serve-dir', defaultsTo: "web")
       ..addOption("host", defaultsTo: "localhost")
       ..addOption("port", defaultsTo: "8080")
-      ..addFlag("app-engine", defaultsTo: true);
+      ..addFlag("app-engine", defaultsTo: false);
 
   var params = parser.parse(args);
 
   react_server.setServerConfiguration();
 
   app.setupConsoleLog();
-  app.setUp();
+  await app.redstoneSetUp();
 
   if (params["app-engine"]) {
     app.setShelfHandler(shelf_ae.assetHandler(
@@ -37,7 +37,7 @@ void main(List<String> args) {
 }
 
 @app.Route("/", responseType: "text/html")
-String root() => renderTemplate(new State("/", {}));
+String root() => renderTemplate(new State(app.request.url.toString(), {}));
 
 @app.Route("/search", responseType: "text/html")
 searchMovieWithQuery(@app.QueryParam("q") String query) async {

--- a/lib/src/components/application.dart
+++ b/lib/src/components/application.dart
@@ -39,12 +39,12 @@ class _ApplicationView extends Component {
   }
 
   _renderPath(String path, Map data) {
-    if (path == "/") {
+    if (path == "") {
       return homeView(_search);
-    } else if (path.startsWith("/search")) {
+    } else if (path.startsWith("search")) {
       var movies = data["movies"].map((json) => new Movie.fromJson(json));
       return searchResultsView(data["term"], movies, _search, _selectMovie);
-    } else if (path.startsWith("/movie")) {
+    } else if (path.startsWith("movie")) {
       var movie = new Movie.fromJson(data["movie"]);
       return movieDetailView(movie);
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   browser: any
   frappe: any
   http: any
-  redstone: any
+  redstone: 0.6.0-beta.1+3
   react: any
   shelf_appengine: any
   shelf_static: any


### PR DESCRIPTION
- Update redstone.dart to 0.6.0-beta1+3
  - Update import statement
  - Update server.dart.setUp() to bootstrap.dart.redstoneSetUp() (with await & async)
- Update compatibility with Shelf 0.6.0+
  - request.url does not include preceeding '/'
  - https://github.com/dart-lang/shelf/blob/master/CHANGELOG.md
